### PR TITLE
fix(remove-lines): add checking for property existing

### DIFF
--- a/src/remove-lines.js
+++ b/src/remove-lines.js
@@ -53,6 +53,7 @@ export default function removeLines (magicString, code, file, options) {
       // strip away propTypes or defaultProps definitions
       if (node.type === 'ExpressionStatement' && 
           node.expression.type === 'AssignmentExpression' &&
+          node.expression.left.property &&
          (node.expression.left.property.name === 'propTypes' ||
           node.expression.left.property.name === 'defaultProps')) {
         remove( node.start, node.end )


### PR DESCRIPTION
**What**: Validation for property node.expression.left.property has been added.

**Why**: In our project build failed due to error "(stripPropTypes plugin) TypeError: Cannot read property 'left' of undefined".

**How**: Add checking for property existing.